### PR TITLE
Feature/TOB-5176

### DIFF
--- a/src/components/tables/FagomraaderTable.tsx
+++ b/src/components/tables/FagomraaderTable.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router";
 import { Button, Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Fagomraader } from "../../types/Fagomraader";
+import { KLASSEKODER } from "../../util/constant";
 import { SortState, sortData } from "../../util/sortUtil";
 import FagomraaderExpandableSection from "../expandablesections/FagomraaderExpandableSection";
 import BilagstypeModal from "../modals/BilagstypeModal";
@@ -15,6 +17,7 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
   const [sort, setSort] = useState<SortState<Fagomraader> | undefined>();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(10);
+  const navigate = useNavigate();
 
   const sortedData = sortData(data, sort);
 
@@ -23,6 +26,10 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
     (currentPage - 1) * pageSize,
     currentPage * pageSize,
   );
+
+  const handleKlassekodeClick = (fagomraade: string) => {
+    navigate(`${KLASSEKODER}?fagomraade=${encodeURIComponent(fagomraade)}`);
+  };
 
   return (
     <>
@@ -81,6 +88,7 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
                   variant="tertiary"
                   size="xsmall"
                   disabled={!row.klassekodeFinnes}
+                  onClick={() => handleKlassekodeClick(row.kodeFagomraade)}
                 >
                   Klassekode
                 </Button>

--- a/src/components/tables/FagomraaderTable.tsx
+++ b/src/components/tables/FagomraaderTable.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router";
-import { Button, Pagination, Table } from "@navikt/ds-react";
+import { useState } from "react";
+import { Link as RouterLink } from "react-router";
+import { Link, Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Fagomraader } from "../../types/Fagomraader";
 import { KLASSEKODER } from "../../util/constant";
@@ -17,7 +17,6 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
   const [sort, setSort] = useState<SortState<Fagomraader> | undefined>();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(10);
-  const navigate = useNavigate();
 
   const sortedData = sortData(data, sort);
 
@@ -26,10 +25,6 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
     (currentPage - 1) * pageSize,
     currentPage * pageSize,
   );
-
-  const handleKlassekodeClick = (fagomraade: string) => {
-    navigate(`${KLASSEKODER}?fagomraade=${encodeURIComponent(fagomraade)}`);
-  };
 
   return (
     <>
@@ -84,14 +79,16 @@ export const FagomraaderTable = ({ data = [] }: Props) => {
                 />
               </Table.DataCell>
               <Table.DataCell>
-                <Button
-                  variant="tertiary"
-                  size="xsmall"
-                  disabled={!row.klassekodeFinnes}
-                  onClick={() => handleKlassekodeClick(row.kodeFagomraade)}
-                >
-                  Klassekode
-                </Button>
+                {row.klassekodeFinnes ? (
+                  <Link
+                    as={RouterLink}
+                    to={`${KLASSEKODER}?fagomraade=${encodeURIComponent(row.kodeFagomraade)}`}
+                  >
+                    Klassekode
+                  </Link>
+                ) : (
+                  "Ingen"
+                )}
               </Table.DataCell>
             </FagomraaderExpandableSection>
           ))}

--- a/src/components/tables/KlassekoderTable.tsx
+++ b/src/components/tables/KlassekoderTable.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Pagination, Table } from "@navikt/ds-react";
+import { useNavigate } from "react-router";
+import { Button, Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Klassekoder } from "../../types/Klassekoder";
+import { FAGOMRAADER } from "../../util/constant";
 import { SortState, sortData } from "../../util/sortUtil";
 
 interface Props {
@@ -12,11 +14,16 @@ export const KlassekoderTable = ({ data = [] }: Props) => {
   const [sort, setSort] = useState<SortState<Klassekoder> | undefined>();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(10);
+  const navigate = useNavigate();
 
   // Reset to page 1 when filtered data changes
   useEffect(() => {
     setCurrentPage(1);
   }, [data]);
+
+  const handleFagomraadeClick = (fagomraade: string) => {
+    navigate(`${FAGOMRAADER}?fagomraade=${encodeURIComponent(fagomraade)}`);
+  };
 
   const sortedData = sortData(data, sort);
   const totalPages = Math.ceil(sortedData.length / pageSize);
@@ -70,7 +77,19 @@ export const KlassekoderTable = ({ data = [] }: Props) => {
               <Table.DataCell>{row.datoTom}</Table.DataCell>
               <Table.DataCell>{row.hovedkontoNr}</Table.DataCell>
               <Table.DataCell>{row.underkontoNr}</Table.DataCell>
-              <Table.DataCell>{row.kodeFagomraade || "Ingen"}</Table.DataCell>
+              <Table.DataCell>
+                {row.kodeFagomraade ? (
+                  <Button
+                    variant="tertiary"
+                    size="xsmall"
+                    onClick={() => handleFagomraadeClick(row.kodeFagomraade!)}
+                  >
+                    {row.kodeFagomraade}
+                  </Button>
+                ) : (
+                  "Ingen"
+                )}
+              </Table.DataCell>
             </Table.Row>
           ))}
         </Table.Body>

--- a/src/components/tables/KlassekoderTable.tsx
+++ b/src/components/tables/KlassekoderTable.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
-import { Button, Pagination, Table } from "@navikt/ds-react";
+import { useEffect, useState } from "react";
+import { Link as RouterLink } from "react-router";
+import { Link, Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Klassekoder } from "../../types/Klassekoder";
 import { FAGOMRAADER } from "../../util/constant";
@@ -14,16 +14,11 @@ export const KlassekoderTable = ({ data = [] }: Props) => {
   const [sort, setSort] = useState<SortState<Klassekoder> | undefined>();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(10);
-  const navigate = useNavigate();
 
   // Reset to page 1 when filtered data changes
   useEffect(() => {
     setCurrentPage(1);
   }, [data]);
-
-  const handleFagomraadeClick = (fagomraade: string) => {
-    navigate(`${FAGOMRAADER}?fagomraade=${encodeURIComponent(fagomraade)}`);
-  };
 
   const sortedData = sortData(data, sort);
   const totalPages = Math.ceil(sortedData.length / pageSize);
@@ -79,13 +74,12 @@ export const KlassekoderTable = ({ data = [] }: Props) => {
               <Table.DataCell>{row.underkontoNr}</Table.DataCell>
               <Table.DataCell>
                 {row.kodeFagomraade ? (
-                  <Button
-                    variant="tertiary"
-                    size="xsmall"
-                    onClick={() => handleFagomraadeClick(row.kodeFagomraade!)}
+                  <Link
+                    as={RouterLink}
+                    to={`${FAGOMRAADER}?fagomraade=${encodeURIComponent(row.kodeFagomraade)}`}
                   >
                     {row.kodeFagomraade}
-                  </Button>
+                  </Link>
                 ) : (
                   "Ingen"
                 )}

--- a/src/components/tables/VentekriterierTable.tsx
+++ b/src/components/tables/VentekriterierTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Ventekriterier } from "../../types/Ventekriterier";

--- a/src/components/tables/VentestatuskoderTable.tsx
+++ b/src/components/tables/VentestatuskoderTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Pagination, Table } from "@navikt/ds-react";
 import commonstyles from "../../styles/Commonstyles.module.css";
 import { Ventestatuskoder } from "../../types/Ventestatuskoder";

--- a/src/pages/FagomraaderPage.tsx
+++ b/src/pages/FagomraaderPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { Alert, Heading } from "@navikt/ds-react";
 import { useGetFagomraader } from "../api/apiService";
@@ -11,37 +11,36 @@ import commonstyles from "../styles/Commonstyles.module.css";
 export const FagomraaderPage = () => {
   const { data, error, isLoading } = useGetFagomraader();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [isInitialized, setIsInitialized] = useState(false);
 
-  useEffect(() => {
+  const activeFilters = useMemo(() => {
     const fagomraadeParam = searchParams.get("fagomraade");
-    if (fagomraadeParam && data && !isInitialized) {
-      const matchingItem = data.find(
-        (item) => item.kodeFagomraade === fagomraadeParam,
-      );
-      if (matchingItem) {
-        const filterValue = `${matchingItem.kodeFagomraade} - ${matchingItem.navnFagomraade}`;
-        setActiveFilters([filterValue]);
-      }
-      setIsInitialized(true);
-    } else if (!fagomraadeParam && data && !isInitialized) {
-      setIsInitialized(true);
+    if (!fagomraadeParam || !data) return [];
+
+    const matchingItem = data.find(
+      (item) => item.kodeFagomraade === fagomraadeParam,
+    );
+
+    if (matchingItem) {
+      return [
+        `${matchingItem.kodeFagomraade} - ${matchingItem.navnFagomraade}`,
+      ];
     }
-  }, [searchParams, data, isInitialized]);
 
-  useEffect(() => {
-    if (!isInitialized) return;
+    return [];
+  }, [searchParams, data]);
 
+  const handleFiltersChange = (newFilters: string[]) => {
     const newSearchParams = new URLSearchParams(searchParams);
-    if (activeFilters.length > 0) {
-      const fagomraadeCode = activeFilters[0].split(" - ")[0];
+
+    if (newFilters.length > 0) {
+      const fagomraadeCode = newFilters[0].split(" - ")[0];
       newSearchParams.set("fagomraade", fagomraadeCode);
     } else {
       newSearchParams.delete("fagomraade");
     }
+
     setSearchParams(newSearchParams, { replace: true });
-  }, [activeFilters, isInitialized, searchParams, setSearchParams]);
+  };
 
   const filteredData = useMemo(() => {
     if (!data || activeFilters.length === 0) return data || [];
@@ -74,7 +73,7 @@ export const FagomraaderPage = () => {
           <FagomraaderFilter
             data={data}
             activeFilters={activeFilters}
-            onFiltersChange={setActiveFilters}
+            onFiltersChange={handleFiltersChange}
           />
         )}
 

--- a/src/pages/KlassekoderPage.tsx
+++ b/src/pages/KlassekoderPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { Alert, Heading } from "@navikt/ds-react";
 import { useGetKlassekoder } from "../api/apiService";
@@ -16,33 +16,21 @@ export const KlassekoderPage = () => {
   const { data, error, isLoading } = useGetKlassekoder();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [filters, setFilters] = useState({
-    klassekoder: [] as string[],
-    hovedkontoNr: [] as string[],
-    underkontoNr: [] as string[],
-    artID: [] as string[],
-    fagomraade: [] as string[],
-  });
-
-  useEffect(() => {
+  const filters = useMemo(() => {
     const fagomraadeParam = searchParams.get("fagomraade");
-    if (fagomraadeParam) {
-      setFilters((prev) => ({
-        ...prev,
-        fagomraade: [fagomraadeParam],
-      }));
-    }
+    return {
+      klassekoder: [] as string[],
+      hovedkontoNr: [] as string[],
+      underkontoNr: [] as string[],
+      artID: [] as string[],
+      fagomraade: fagomraadeParam ? [fagomraadeParam] : ([] as string[]),
+    };
   }, [searchParams]);
 
   const handleFilterChange = (
     field: keyof typeof filters,
     values: string[],
   ) => {
-    setFilters((prev) => ({
-      ...prev,
-      [field]: values,
-    }));
-
     const newSearchParams = new URLSearchParams(searchParams);
     if (field === "fagomraade") {
       if (values.length > 0) {

--- a/src/pages/KlassekoderPage.tsx
+++ b/src/pages/KlassekoderPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { Alert, Heading } from "@navikt/ds-react";
 import { useGetKlassekoder } from "../api/apiService";
@@ -14,31 +14,32 @@ import {
 
 export const KlassekoderPage = () => {
   const { data, error, isLoading } = useGetKlassekoder();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [urlParameters, setUrlParameters] = useSearchParams();
 
-  const filters = useMemo(() => {
-    const fagomraadeParam = searchParams.get("fagomraade");
+  const [filters, setFilters] = useState(() => {
+    const fagomraadeUrlParam = urlParameters.get("fagomraade");
     return {
       klassekoder: [] as string[],
       hovedkontoNr: [] as string[],
       underkontoNr: [] as string[],
       artID: [] as string[],
-      fagomraade: fagomraadeParam ? [fagomraadeParam] : ([] as string[]),
+      fagomraade: fagomraadeUrlParam ? [fagomraadeUrlParam] : ([] as string[]),
     };
-  }, [searchParams]);
+  });
 
   const handleFilterChange = (
     field: keyof typeof filters,
     values: string[],
   ) => {
-    const newSearchParams = new URLSearchParams(searchParams);
-    if (field === "fagomraade") {
-      if (values.length > 0) {
-        newSearchParams.set("fagomraade", values[0]);
-      } else {
-        newSearchParams.delete("fagomraade");
-      }
-      setSearchParams(newSearchParams);
+    setFilters((prev) => ({
+      ...prev,
+      [field]: values,
+    }));
+
+    if (field === "fagomraade" && values.length === 0) {
+      const newUrlParameter = new URLSearchParams(urlParameters);
+      newUrlParameter.delete("fagomraade");
+      setUrlParameters(newUrlParameter, { replace: true });
     }
   };
 

--- a/src/pages/KlassekoderPage.tsx
+++ b/src/pages/KlassekoderPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
 import { Alert, Heading } from "@navikt/ds-react";
 import { useGetKlassekoder } from "../api/apiService";
 import BackHomeBox from "../components/backhomebox/BackHomeBox";
@@ -13,6 +14,7 @@ import {
 
 export const KlassekoderPage = () => {
   const { data, error, isLoading } = useGetKlassekoder();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [filters, setFilters] = useState({
     klassekoder: [] as string[],
@@ -22,6 +24,16 @@ export const KlassekoderPage = () => {
     fagomraade: [] as string[],
   });
 
+  useEffect(() => {
+    const fagomraadeParam = searchParams.get("fagomraade");
+    if (fagomraadeParam) {
+      setFilters((prev) => ({
+        ...prev,
+        fagomraade: [fagomraadeParam],
+      }));
+    }
+  }, [searchParams]);
+
   const handleFilterChange = (
     field: keyof typeof filters,
     values: string[],
@@ -30,6 +42,16 @@ export const KlassekoderPage = () => {
       ...prev,
       [field]: values,
     }));
+
+    const newSearchParams = new URLSearchParams(searchParams);
+    if (field === "fagomraade") {
+      if (values.length > 0) {
+        newSearchParams.set("fagomraade", values[0]);
+      } else {
+        newSearchParams.delete("fagomraade");
+      }
+      setSearchParams(newSearchParams);
+    }
   };
 
   const filteredData = useMemo(() => {
@@ -38,8 +60,8 @@ export const KlassekoderPage = () => {
   }, [data, filters]);
 
   const availableOptions = useMemo(() => {
-    return getAvailableOptions(filteredData);
-  }, [filteredData]);
+    return getAvailableOptions(data || []);
+  }, [data]);
 
   if (isLoading) return <ContentLoader />;
 

--- a/src/pages/KlassekoderPage.tsx
+++ b/src/pages/KlassekoderPage.tsx
@@ -49,8 +49,8 @@ export const KlassekoderPage = () => {
   }, [data, filters]);
 
   const availableOptions = useMemo(() => {
-    return getAvailableOptions(data || []);
-  }, [data]);
+    return getAvailableOptions(filteredData);
+  }, [filteredData]);
 
   if (isLoading) return <ContentLoader />;
 


### PR DESCRIPTION
Legger til støtte for navigering mellom klassekoder og fagområder sidene med URL parametere. Støtter filtrering basert på parameterne.

TODO:

Flytt logikk for kombinering av visningsfagområde ( navnFagomraade + kodeFagomraade) til selve Filterkomponenten for å unngå å duplisere denne logikken flere steder. Tenker det er best at "page" komponentene bare forholder seg til rådata så mye som mulig; hente denne, og sende videre til andre komponenter som kan transformere etter behov